### PR TITLE
fix: close tabs of current window only

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -61,7 +61,7 @@ const CloseTabs = () => {
   chrome.storage.sync.get("tabsToClose", obj => {
     const wantedRegex = getWantedRegex(obj.tabsToClose);
 
-    chrome.tabs.query({}, tabs => {
+    chrome.tabs.query({ currentWindow: true }, tabs => {
       let tabIdsToRemove = findTabsByUrl(tabs, wantedRegex);
       chrome.tabs.remove(tabIdsToRemove);
     });


### PR DESCRIPTION
Thank you for the extension :smile:  ! 

Personally, I tend to use other windows for other problems/bugs/purposes, and they often include google and stackoverflow tabs as well. Perhaps it is better to only close the tabs of the current window. 

Feel free to ignore this PR if this is not the intent of the extension. 